### PR TITLE
Implement robust pending message deletion by Tid

### DIFF
--- a/SceytChatUiKit/schemas/com.sceyt.chatuikit.persistence.database.SceytDatabase/31.json
+++ b/SceytChatUiKit/schemas/com.sceyt.chatuikit.persistence.database.SceytDatabase/31.json
@@ -1,0 +1,2501 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 31,
+    "identityHash": "107b1b6958dabe83265a7b159ee776e2",
+    "entities": [
+      {
+        "tableName": "sceyt_channel_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chat_id` INTEGER NOT NULL, `parentChannelId` INTEGER, `uri` TEXT, `type` TEXT NOT NULL, `subject` TEXT, `avatarUrl` TEXT, `metadata` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `messagesClearedAt` INTEGER NOT NULL, `memberCount` INTEGER NOT NULL, `createdById` TEXT, `userRole` TEXT, `unread` INTEGER NOT NULL, `newMessageCount` INTEGER NOT NULL, `newMentionCount` INTEGER NOT NULL, `newReactedMessageCount` INTEGER NOT NULL, `hidden` INTEGER NOT NULL, `archived` INTEGER NOT NULL, `muted` INTEGER NOT NULL, `mutedTill` INTEGER, `pinnedAt` INTEGER, `lastReceivedMessageId` INTEGER NOT NULL, `lastDisplayedMessageId` INTEGER NOT NULL, `messageRetentionPeriod` INTEGER NOT NULL, `lastMessageTid` INTEGER, `lastMessageAt` INTEGER, `pending` INTEGER NOT NULL, `isSelf` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`chat_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "parentChannelId",
+            "columnName": "parentChannelId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "uri",
+            "columnName": "uri",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "subject",
+            "columnName": "subject",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarUrl",
+            "columnName": "avatarUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messagesClearedAt",
+            "columnName": "messagesClearedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "memberCount",
+            "columnName": "memberCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdById",
+            "columnName": "createdById",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "userRole",
+            "columnName": "userRole",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "unread",
+            "columnName": "unread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newMessageCount",
+            "columnName": "newMessageCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newMentionCount",
+            "columnName": "newMentionCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "newReactedMessageCount",
+            "columnName": "newReactedMessageCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "hidden",
+            "columnName": "hidden",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "archived",
+            "columnName": "archived",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "muted",
+            "columnName": "muted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mutedTill",
+            "columnName": "mutedTill",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pinnedAt",
+            "columnName": "pinnedAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastReceivedMessageId",
+            "columnName": "lastReceivedMessageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastDisplayedMessageId",
+            "columnName": "lastDisplayedMessageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageRetentionPeriod",
+            "columnName": "messageRetentionPeriod",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastMessageTid",
+            "columnName": "lastMessageTid",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastMessageAt",
+            "columnName": "lastMessageAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "pending",
+            "columnName": "pending",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isSelf",
+            "columnName": "isSelf",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chat_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_channel_table_uri",
+            "unique": true,
+            "columnNames": [
+              "uri"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_channel_table_uri` ON `${TABLE_NAME}` (`uri`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_type` ON `${TABLE_NAME}` (`type`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_subject",
+            "unique": false,
+            "columnNames": [
+              "subject"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_subject` ON `${TABLE_NAME}` (`subject`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_userRole",
+            "unique": false,
+            "columnNames": [
+              "userRole"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_userRole` ON `${TABLE_NAME}` (`userRole`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_pinnedAt",
+            "unique": false,
+            "columnNames": [
+              "pinnedAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_pinnedAt` ON `${TABLE_NAME}` (`pinnedAt`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_lastMessageAt",
+            "unique": false,
+            "columnNames": [
+              "lastMessageAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_lastMessageAt` ON `${TABLE_NAME}` (`lastMessageAt`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_pending",
+            "unique": false,
+            "columnNames": [
+              "pending"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_pending` ON `${TABLE_NAME}` (`pending`)"
+          },
+          {
+            "name": "index_sceyt_channel_table_isSelf",
+            "unique": false,
+            "columnNames": [
+              "isSelf"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_channel_table_isSelf` ON `${TABLE_NAME}` (`isSelf`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_channel_sync_state_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`channelId` INTEGER NOT NULL, `lastSyncedMessageId` INTEGER NOT NULL, PRIMARY KEY(`channelId`))",
+        "fields": [
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "lastSyncedMessageId",
+            "columnName": "lastSyncedMessageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "channelId"
+          ]
+        }
+      },
+      {
+        "tableName": "sceyt_user_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` TEXT NOT NULL, `username` TEXT NOT NULL DEFAULT '', `firstName` TEXT, `lastName` TEXT, `avatarURL` TEXT, `activityStatus` INTEGER, `blocked` INTEGER NOT NULL, `state` INTEGER, `status` TEXT, `lastActiveAt` INTEGER, PRIMARY KEY(`user_id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "username",
+            "columnName": "username",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "avatarURL",
+            "columnName": "avatarURL",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "activityStatus",
+            "columnName": "activityStatus",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "blocked",
+            "columnName": "blocked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "presence.state",
+            "columnName": "state",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "presence.status",
+            "columnName": "status",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "presence.lastActiveAt",
+            "columnName": "lastActiveAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "user_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_user_table_username",
+            "unique": false,
+            "columnNames": [
+              "username"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_user_table_username` ON `${TABLE_NAME}` (`username`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_user_chat_link_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `user_id` TEXT NOT NULL, `chat_id` INTEGER NOT NULL, `role` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "chatId",
+            "columnName": "chat_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "role",
+            "columnName": "role",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "uniqueUserInChat",
+            "unique": true,
+            "columnNames": [
+              "chat_id",
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `uniqueUserInChat` ON `${TABLE_NAME}` (`chat_id`, `user_id`)"
+          },
+          {
+            "name": "index_sceyt_user_chat_link_table_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_user_chat_link_table_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          },
+          {
+            "name": "index_sceyt_user_chat_link_table_chat_id",
+            "unique": false,
+            "columnNames": [
+              "chat_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_user_chat_link_table_chat_id` ON `${TABLE_NAME}` (`chat_id`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_message_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`tid` INTEGER NOT NULL, `message_id` INTEGER, `channelId` INTEGER NOT NULL, `body` TEXT NOT NULL, `type` TEXT NOT NULL, `metadata` TEXT, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `incoming` INTEGER NOT NULL, `isTransient` INTEGER NOT NULL, `silent` INTEGER NOT NULL, `viewOnce` INTEGER NOT NULL DEFAULT 0, `deliveryStatus` INTEGER NOT NULL, `state` INTEGER NOT NULL, `fromId` TEXT, `markerCount` TEXT, `mentionedUsersIds` TEXT, `parentId` INTEGER, `replyCount` INTEGER NOT NULL, `displayCount` INTEGER NOT NULL, `autoDeleteAt` INTEGER, `bodyAttribute` TEXT, `disableMentionsCount` INTEGER NOT NULL DEFAULT 0, `unList` INTEGER NOT NULL, `messageId` INTEGER, `userId` TEXT, `hops` INTEGER, PRIMARY KEY(`tid`))",
+        "fields": [
+          {
+            "fieldPath": "tid",
+            "columnName": "tid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "message_id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incoming",
+            "columnName": "incoming",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isTransient",
+            "columnName": "isTransient",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "silent",
+            "columnName": "silent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "viewOnce",
+            "columnName": "viewOnce",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "deliveryStatus",
+            "columnName": "deliveryStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromId",
+            "columnName": "fromId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "markerCount",
+            "columnName": "markerCount",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "mentionedUsersIds",
+            "columnName": "mentionedUsersIds",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "parentId",
+            "columnName": "parentId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "replyCount",
+            "columnName": "replyCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "displayCount",
+            "columnName": "displayCount",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDeleteAt",
+            "columnName": "autoDeleteAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "bodyAttribute",
+            "columnName": "bodyAttribute",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "disableMentionsCount",
+            "columnName": "disableMentionsCount",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "unList",
+            "columnName": "unList",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "forwardingDetailsDb.messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "forwardingDetailsDb.userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "forwardingDetailsDb.hops",
+            "columnName": "hops",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "tid"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_message_table_message_id",
+            "unique": true,
+            "columnNames": [
+              "message_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_message_table_message_id` ON `${TABLE_NAME}` (`message_id`)"
+          },
+          {
+            "name": "index_sceyt_message_table_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_message_table_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          },
+          {
+            "name": "index_sceyt_message_table_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_message_table_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_sceyt_message_table_deliveryStatus",
+            "unique": false,
+            "columnNames": [
+              "deliveryStatus"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_message_table_deliveryStatus` ON `${TABLE_NAME}` (`deliveryStatus`)"
+          },
+          {
+            "name": "index_sceyt_message_table_unList",
+            "unique": false,
+            "columnNames": [
+              "unList"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_message_table_unList` ON `${TABLE_NAME}` (`unList`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_mention_user_message_link_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageTid` INTEGER NOT NULL, `user_id` TEXT NOT NULL, PRIMARY KEY(`messageTid`, `user_id`), FOREIGN KEY(`messageTid`) REFERENCES `sceyt_message_table`(`tid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "messageTid",
+            "columnName": "messageTid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageTid",
+            "user_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_mention_user_message_link_table_messageTid",
+            "unique": false,
+            "columnNames": [
+              "messageTid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_mention_user_message_link_table_messageTid` ON `${TABLE_NAME}` (`messageTid`)"
+          },
+          {
+            "name": "index_sceyt_mention_user_message_link_table_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_mention_user_message_link_table_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageTid"
+            ],
+            "referencedColumns": [
+              "tid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_draft_message_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chatId` INTEGER NOT NULL, `message` TEXT, `createdAt` INTEGER NOT NULL, `replyOrEditMessageId` INTEGER, `isReplyMessage` INTEGER, `styleRanges` TEXT, `viewOnce` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`chatId`))",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "message",
+            "columnName": "message",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "replyOrEditMessageId",
+            "columnName": "replyOrEditMessageId",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "isReplyMessage",
+            "columnName": "isReplyMessage",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "styleRanges",
+            "columnName": "styleRanges",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewOnce",
+            "columnName": "viewOnce",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chatId"
+          ]
+        }
+      },
+      {
+        "tableName": "sceyt_draft_attachment_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chatId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `type` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`chatId`) REFERENCES `sceyt_draft_message_table`(`chatId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_draft_attachment_table_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_draft_attachment_table_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_draft_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "chatId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_draft_voice_attachment_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chatId` INTEGER NOT NULL, `filePath` TEXT NOT NULL, `duration` INTEGER NOT NULL, `amplitudes` TEXT NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`chatId`) REFERENCES `sceyt_draft_message_table`(`chatId`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "duration",
+            "columnName": "duration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amplitudes",
+            "columnName": "amplitudes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_draft_voice_attachment_table_chatId",
+            "unique": false,
+            "columnNames": [
+              "chatId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_draft_voice_attachment_table_chatId` ON `${TABLE_NAME}` (`chatId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_draft_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "chatId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_draft_message_user_link_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`chatId` INTEGER NOT NULL, `user_id` TEXT NOT NULL, PRIMARY KEY(`chatId`, `user_id`), FOREIGN KEY(`chatId`) REFERENCES `sceyt_draft_message_table`(`chatId`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "chatId",
+            "columnName": "chatId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "chatId",
+            "user_id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_draft_message_user_link_table_user_id",
+            "unique": false,
+            "columnNames": [
+              "user_id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_draft_message_user_link_table_user_id` ON `${TABLE_NAME}` (`user_id`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_draft_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "chatId"
+            ],
+            "referencedColumns": [
+              "chatId"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_attachment_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`primaryKey` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` INTEGER, `messageId` INTEGER NOT NULL, `messageTid` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `userId` TEXT, `name` TEXT NOT NULL, `type` TEXT NOT NULL, `metadata` TEXT, `fileSize` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `url` TEXT, `filePath` TEXT, `originalFilePath` TEXT, `viewOnce` INTEGER NOT NULL DEFAULT 0, FOREIGN KEY(`messageTid`) REFERENCES `sceyt_message_table`(`tid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "primaryKey",
+            "columnName": "primaryKey",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTid",
+            "columnName": "messageTid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "originalFilePath",
+            "columnName": "originalFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "viewOnce",
+            "columnName": "viewOnce",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "primaryKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_attachment_table_messageTid_url",
+            "unique": true,
+            "columnNames": [
+              "messageTid",
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_attachment_table_messageTid_url` ON `${TABLE_NAME}` (`messageTid`, `url`)"
+          },
+          {
+            "name": "index_sceyt_attachment_table_id",
+            "unique": false,
+            "columnNames": [
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_attachment_table_id` ON `${TABLE_NAME}` (`id`)"
+          },
+          {
+            "name": "index_sceyt_attachment_table_messageTid",
+            "unique": false,
+            "columnNames": [
+              "messageTid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_attachment_table_messageTid` ON `${TABLE_NAME}` (`messageTid`)"
+          },
+          {
+            "name": "index_sceyt_attachment_table_type",
+            "unique": false,
+            "columnNames": [
+              "type"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_attachment_table_type` ON `${TABLE_NAME}` (`type`)"
+          },
+          {
+            "name": "index_sceyt_attachment_table_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_attachment_table_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          },
+          {
+            "name": "index_sceyt_attachment_table_url",
+            "unique": false,
+            "columnNames": [
+              "url"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_attachment_table_url` ON `${TABLE_NAME}` (`url`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageTid"
+            ],
+            "referencedColumns": [
+              "tid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_marker_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` INTEGER NOT NULL, `userId` TEXT NOT NULL, `name` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`messageId`, `name`, `userId`), FOREIGN KEY(`messageId`) REFERENCES `sceyt_message_table`(`message_id`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId",
+            "name",
+            "userId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_marker_table_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_marker_table_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_sceyt_marker_table_name",
+            "unique": false,
+            "columnNames": [
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_marker_table_name` ON `${TABLE_NAME}` (`name`)"
+          },
+          {
+            "name": "index_sceyt_marker_table_createdAt",
+            "unique": false,
+            "columnNames": [
+              "createdAt"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_marker_table_createdAt` ON `${TABLE_NAME}` (`createdAt`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "message_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_reaction_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `messageId` INTEGER NOT NULL, `reaction_key` TEXT NOT NULL, `score` INTEGER NOT NULL, `reason` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `fromId` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`messageId`) REFERENCES `sceyt_message_table`(`message_id`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "reaction_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromId",
+            "columnName": "fromId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_reaction_table_messageId_reaction_key_fromId",
+            "unique": true,
+            "columnNames": [
+              "messageId",
+              "reaction_key",
+              "fromId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_reaction_table_messageId_reaction_key_fromId` ON `${TABLE_NAME}` (`messageId`, `reaction_key`, `fromId`)"
+          },
+          {
+            "name": "index_sceyt_reaction_table_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_reaction_table_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_sceyt_reaction_table_reaction_key",
+            "unique": false,
+            "columnNames": [
+              "reaction_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_reaction_table_reaction_key` ON `${TABLE_NAME}` (`reaction_key`)"
+          },
+          {
+            "name": "index_sceyt_reaction_table_fromId",
+            "unique": false,
+            "columnNames": [
+              "fromId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_reaction_table_fromId` ON `${TABLE_NAME}` (`fromId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "message_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_reaction_total_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageId` INTEGER NOT NULL, `reaction_key` TEXT NOT NULL, `score` INTEGER NOT NULL, `count` INTEGER NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `sceyt_message_table`(`message_id`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "reaction_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_reaction_total_table_messageId_reaction_key",
+            "unique": true,
+            "columnNames": [
+              "messageId",
+              "reaction_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_reaction_total_table_messageId_reaction_key` ON `${TABLE_NAME}` (`messageId`, `reaction_key`)"
+          },
+          {
+            "name": "index_sceyt_reaction_total_table_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_reaction_total_table_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_sceyt_reaction_total_table_reaction_key",
+            "unique": false,
+            "columnNames": [
+              "reaction_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_reaction_total_table_reaction_key` ON `${TABLE_NAME}` (`reaction_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "message_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_chat_user_reaction_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER NOT NULL, `messageId` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `reaction_key` TEXT NOT NULL, `score` INTEGER NOT NULL, `reason` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `fromId` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "reaction_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fromId",
+            "columnName": "fromId",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_chat_user_reaction_table_messageId_channelId_reaction_key_fromId",
+            "unique": true,
+            "columnNames": [
+              "messageId",
+              "channelId",
+              "reaction_key",
+              "fromId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_chat_user_reaction_table_messageId_channelId_reaction_key_fromId` ON `${TABLE_NAME}` (`messageId`, `channelId`, `reaction_key`, `fromId`)"
+          },
+          {
+            "name": "index_sceyt_chat_user_reaction_table_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_chat_user_reaction_table_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_sceyt_chat_user_reaction_table_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_chat_user_reaction_table_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          },
+          {
+            "name": "index_sceyt_chat_user_reaction_table_reaction_key",
+            "unique": false,
+            "columnNames": [
+              "reaction_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_chat_user_reaction_table_reaction_key` ON `${TABLE_NAME}` (`reaction_key`)"
+          },
+          {
+            "name": "index_sceyt_chat_user_reaction_table_fromId",
+            "unique": false,
+            "columnNames": [
+              "fromId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_chat_user_reaction_table_fromId` ON `${TABLE_NAME}` (`fromId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_pending_marker_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`primaryKey` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `channelId` INTEGER NOT NULL, `messageId` INTEGER NOT NULL, `name` TEXT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `sceyt_message_table`(`message_id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "primaryKey",
+            "columnName": "primaryKey",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "primaryKey"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_pending_marker_table_messageId_name",
+            "unique": true,
+            "columnNames": [
+              "messageId",
+              "name"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_pending_marker_table_messageId_name` ON `${TABLE_NAME}` (`messageId`, `name`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "message_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_pending_reaction_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` INTEGER NOT NULL, `reaction_key` TEXT NOT NULL, `score` INTEGER NOT NULL, `reason` TEXT NOT NULL DEFAULT '', `enforceUnique` INTEGER NOT NULL DEFAULT false, `count` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `isAdd` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `incomingMsg` INTEGER NOT NULL DEFAULT false, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`messageId`) REFERENCES `sceyt_message_table`(`message_id`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "reaction_key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "score",
+            "columnName": "score",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reason",
+            "columnName": "reason",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "enforceUnique",
+            "columnName": "enforceUnique",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "count",
+            "columnName": "count",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAdd",
+            "columnName": "isAdd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "incomingMsg",
+            "columnName": "incomingMsg",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "false"
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_pending_reaction_table_messageId_reaction_key",
+            "unique": true,
+            "columnNames": [
+              "messageId",
+              "reaction_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_pending_reaction_table_messageId_reaction_key` ON `${TABLE_NAME}` (`messageId`, `reaction_key`)"
+          },
+          {
+            "name": "index_sceyt_pending_reaction_table_messageId",
+            "unique": false,
+            "columnNames": [
+              "messageId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_pending_reaction_table_messageId` ON `${TABLE_NAME}` (`messageId`)"
+          },
+          {
+            "name": "index_sceyt_pending_reaction_table_reaction_key",
+            "unique": false,
+            "columnNames": [
+              "reaction_key"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_pending_reaction_table_reaction_key` ON `${TABLE_NAME}` (`reaction_key`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageId"
+            ],
+            "referencedColumns": [
+              "message_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_pending_message_state_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageId` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `state` INTEGER NOT NULL, `editBody` TEXT, `deleteOnlyForMe` INTEGER NOT NULL, PRIMARY KEY(`messageId`))",
+        "fields": [
+          {
+            "fieldPath": "messageId",
+            "columnName": "messageId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "state",
+            "columnName": "state",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "editBody",
+            "columnName": "editBody",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "deleteOnlyForMe",
+            "columnName": "deleteOnlyForMe",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageId"
+          ]
+        }
+      },
+      {
+        "tableName": "sceyt_attachment_payload_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `messageTid` INTEGER NOT NULL, `transferState` INTEGER NOT NULL, `progressPercent` REAL, `url` TEXT, `filePath` TEXT, FOREIGN KEY(`messageTid`) REFERENCES `sceyt_message_table`(`tid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTid",
+            "columnName": "messageTid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "transferState",
+            "columnName": "transferState",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "progressPercent",
+            "columnName": "progressPercent",
+            "affinity": "REAL"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "filePath",
+            "columnName": "filePath",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_attachment_payload_table_messageTid",
+            "unique": true,
+            "columnNames": [
+              "messageTid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_attachment_payload_table_messageTid` ON `${TABLE_NAME}` (`messageTid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageTid"
+            ],
+            "referencedColumns": [
+              "tid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_file_checksum_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`checksum` INTEGER NOT NULL, `resizedFilePath` TEXT, `url` TEXT, `metadata` TEXT, `fileSize` INTEGER, PRIMARY KEY(`checksum`))",
+        "fields": [
+          {
+            "fieldPath": "checksum",
+            "columnName": "checksum",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "resizedFilePath",
+            "columnName": "resizedFilePath",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "metadata",
+            "columnName": "metadata",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "fileSize",
+            "columnName": "fileSize",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "checksum"
+          ]
+        }
+      },
+      {
+        "tableName": "sceyt_link_details_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`link` TEXT NOT NULL, `url` TEXT, `title` TEXT, `description` TEXT, `siteName` TEXT, `faviconUrl` TEXT, `imageUrl` TEXT, `imageWidth` INTEGER, `imageHeight` INTEGER, `thumb` TEXT, PRIMARY KEY(`link`))",
+        "fields": [
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "siteName",
+            "columnName": "siteName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "faviconUrl",
+            "columnName": "faviconUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "imageUrl",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "imageWidth",
+            "columnName": "imageWidth",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "imageHeight",
+            "columnName": "imageHeight",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "thumb",
+            "columnName": "thumb",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "link"
+          ]
+        }
+      },
+      {
+        "tableName": "sceyt_load_range_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`startId` INTEGER NOT NULL, `endId` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `rowId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "startId",
+            "columnName": "startId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endId",
+            "columnName": "endId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rowId",
+            "columnName": "rowId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_load_range_table_startId_channelId",
+            "unique": true,
+            "columnNames": [
+              "startId",
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_load_range_table_startId_channelId` ON `${TABLE_NAME}` (`startId`, `channelId`)"
+          },
+          {
+            "name": "index_sceyt_load_range_table_endId_channelId",
+            "unique": true,
+            "columnNames": [
+              "endId",
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_load_range_table_endId_channelId` ON `${TABLE_NAME}` (`endId`, `channelId`)"
+          },
+          {
+            "name": "index_sceyt_load_range_table_startId",
+            "unique": false,
+            "columnNames": [
+              "startId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_load_range_table_startId` ON `${TABLE_NAME}` (`startId`)"
+          },
+          {
+            "name": "index_sceyt_load_range_table_endId",
+            "unique": false,
+            "columnNames": [
+              "endId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_load_range_table_endId` ON `${TABLE_NAME}` (`endId`)"
+          },
+          {
+            "name": "index_sceyt_load_range_table_channelId",
+            "unique": false,
+            "columnNames": [
+              "channelId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_load_range_table_channelId` ON `${TABLE_NAME}` (`channelId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_auto_delete_messages_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageTid` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `autoDeleteAt` INTEGER NOT NULL, PRIMARY KEY(`messageTid`), FOREIGN KEY(`messageTid`) REFERENCES `sceyt_message_table`(`tid`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "messageTid",
+            "columnName": "messageTid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "autoDeleteAt",
+            "columnName": "autoDeleteAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageTid"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageTid"
+            ],
+            "referencedColumns": [
+              "tid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_user_metadata_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`user_id` TEXT NOT NULL, `key` TEXT NOT NULL, `value` TEXT NOT NULL, PRIMARY KEY(`user_id`, `key`), FOREIGN KEY(`user_id`) REFERENCES `sceyt_user_table`(`user_id`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "userId",
+            "columnName": "user_id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "key",
+            "columnName": "key",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "value",
+            "columnName": "value",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "user_id",
+            "key"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "sceyt_user_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "user_id"
+            ],
+            "referencedColumns": [
+              "user_id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_poll_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `messageTid` INTEGER NOT NULL, `name` TEXT NOT NULL, `description` TEXT NOT NULL, `anonymous` INTEGER NOT NULL, `votesPerOption` TEXT NOT NULL, `allowMultipleVotes` INTEGER NOT NULL, `allowVoteRetract` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `closedAt` INTEGER NOT NULL, `closed` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`messageTid`) REFERENCES `sceyt_message_table`(`tid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "messageTid",
+            "columnName": "messageTid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "anonymous",
+            "columnName": "anonymous",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "votesPerOption",
+            "columnName": "votesPerOption",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allowMultipleVotes",
+            "columnName": "allowMultipleVotes",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "allowVoteRetract",
+            "columnName": "allowVoteRetract",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "closedAt",
+            "columnName": "closedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "closed",
+            "columnName": "closed",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_poll_table_messageTid",
+            "unique": true,
+            "columnNames": [
+              "messageTid"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_poll_table_messageTid` ON `${TABLE_NAME}` (`messageTid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageTid"
+            ],
+            "referencedColumns": [
+              "tid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_poll_option_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `pollId` TEXT NOT NULL, `name` TEXT NOT NULL, `order` INTEGER NOT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`pollId`) REFERENCES `sceyt_poll_table`(`id`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollId",
+            "columnName": "pollId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "order",
+            "columnName": "order",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_poll_option_table_pollId_id",
+            "unique": true,
+            "columnNames": [
+              "pollId",
+              "id"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_poll_option_table_pollId_id` ON `${TABLE_NAME}` (`pollId`, `id`)"
+          },
+          {
+            "name": "index_sceyt_poll_option_table_order",
+            "unique": false,
+            "columnNames": [
+              "order"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_poll_option_table_order` ON `${TABLE_NAME}` (`order`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_poll_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "pollId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_poll_vote_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`pollId` TEXT NOT NULL, `optionId` TEXT NOT NULL, `userId` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`pollId`) REFERENCES `sceyt_poll_table`(`id`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "pollId",
+            "columnName": "pollId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionId",
+            "columnName": "optionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_poll_vote_table_pollId_optionId_userId",
+            "unique": true,
+            "columnNames": [
+              "pollId",
+              "optionId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_poll_vote_table_pollId_optionId_userId` ON `${TABLE_NAME}` (`pollId`, `optionId`, `userId`)"
+          },
+          {
+            "name": "index_sceyt_poll_vote_table_optionId",
+            "unique": false,
+            "columnNames": [
+              "optionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_poll_vote_table_optionId` ON `${TABLE_NAME}` (`optionId`)"
+          },
+          {
+            "name": "index_sceyt_poll_vote_table_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_poll_vote_table_userId` ON `${TABLE_NAME}` (`userId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_poll_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "pollId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_pending_poll_vote_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageTid` INTEGER NOT NULL, `pollId` TEXT NOT NULL, `optionId` TEXT NOT NULL, `userId` TEXT NOT NULL, `isAdd` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, `id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, FOREIGN KEY(`messageTid`) REFERENCES `sceyt_message_table`(`tid`) ON UPDATE CASCADE ON DELETE CASCADE DEFERRABLE INITIALLY DEFERRED)",
+        "fields": [
+          {
+            "fieldPath": "messageTid",
+            "columnName": "messageTid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "pollId",
+            "columnName": "pollId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "optionId",
+            "columnName": "optionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "userId",
+            "columnName": "userId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isAdd",
+            "columnName": "isAdd",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_sceyt_pending_poll_vote_table_pollId_optionId_userId",
+            "unique": true,
+            "columnNames": [
+              "pollId",
+              "optionId",
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_sceyt_pending_poll_vote_table_pollId_optionId_userId` ON `${TABLE_NAME}` (`pollId`, `optionId`, `userId`)"
+          },
+          {
+            "name": "index_sceyt_pending_poll_vote_table_optionId",
+            "unique": false,
+            "columnNames": [
+              "optionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_pending_poll_vote_table_optionId` ON `${TABLE_NAME}` (`optionId`)"
+          },
+          {
+            "name": "index_sceyt_pending_poll_vote_table_userId",
+            "unique": false,
+            "columnNames": [
+              "userId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_pending_poll_vote_table_userId` ON `${TABLE_NAME}` (`userId`)"
+          },
+          {
+            "name": "index_sceyt_pending_poll_vote_table_pollId",
+            "unique": false,
+            "columnNames": [
+              "pollId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_pending_poll_vote_table_pollId` ON `${TABLE_NAME}` (`pollId`)"
+          },
+          {
+            "name": "index_sceyt_pending_poll_vote_table_messageTid",
+            "unique": false,
+            "columnNames": [
+              "messageTid"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_sceyt_pending_poll_vote_table_messageTid` ON `${TABLE_NAME}` (`messageTid`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "sceyt_message_table",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "messageTid"
+            ],
+            "referencedColumns": [
+              "tid"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "sceyt_pending_message_delete_by_tid_table",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`messageTid` INTEGER NOT NULL, `channelId` INTEGER NOT NULL, `deleteType` INTEGER NOT NULL, `createdAt` INTEGER NOT NULL, PRIMARY KEY(`messageTid`))",
+        "fields": [
+          {
+            "fieldPath": "messageTid",
+            "columnName": "messageTid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "channelId",
+            "columnName": "channelId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "deleteType",
+            "columnName": "deleteType",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "messageTid"
+          ]
+        }
+      },
+      {
+        "tableName": "message_fts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`body` TEXT NOT NULL, tokenize=unicode61, content=`sceyt_message_table`)",
+        "fields": [
+          {
+            "fieldPath": "body",
+            "columnName": "body",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "unicode61",
+          "tokenizerArgs": [],
+          "contentTable": "sceyt_message_table",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": [
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_message_fts_BEFORE_UPDATE BEFORE UPDATE ON `sceyt_message_table` BEGIN DELETE FROM `message_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_message_fts_BEFORE_DELETE BEFORE DELETE ON `sceyt_message_table` BEGIN DELETE FROM `message_fts` WHERE `docid`=OLD.`rowid`; END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_message_fts_AFTER_UPDATE AFTER UPDATE ON `sceyt_message_table` BEGIN INSERT INTO `message_fts`(`docid`, `body`) VALUES (NEW.`rowid`, NEW.`body`); END",
+          "CREATE TRIGGER IF NOT EXISTS room_fts_content_sync_message_fts_AFTER_INSERT AFTER INSERT ON `sceyt_message_table` BEGIN INSERT INTO `message_fts`(`docid`, `body`) VALUES (NEW.`rowid`, NEW.`body`); END"
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '107b1b6958dabe83265a7b159ee776e2')"
+    ]
+  }
+}

--- a/SceytChatUiKit/src/androidTest/java/com/sceyt/chatuikit/persistence/dao/PendingMessageDeleteByTidDaoTest.kt
+++ b/SceytChatUiKit/src/androidTest/java/com/sceyt/chatuikit/persistence/dao/PendingMessageDeleteByTidDaoTest.kt
@@ -1,0 +1,173 @@
+package com.sceyt.chatuikit.persistence.dao
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.room.Room
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.SmallTest
+import com.google.common.truth.Truth.assertThat
+import com.sceyt.chat.models.message.DeleteMessageType
+import com.sceyt.chat.models.message.MessageState
+import com.sceyt.chatuikit.data.models.messages.MessageDeliveryStatus
+import com.sceyt.chatuikit.persistence.database.SceytDatabase
+import com.sceyt.chatuikit.persistence.database.dao.MessageDao
+import com.sceyt.chatuikit.persistence.database.dao.PendingMessageDeleteByTidDao
+import com.sceyt.chatuikit.persistence.database.entity.messages.MessageDb
+import com.sceyt.chatuikit.persistence.database.entity.messages.MessageEntity
+import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMessageDeleteByTidEntity
+import kotlinx.coroutines.test.runTest
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@SmallTest
+class PendingMessageDeleteByTidDaoTest {
+
+    private lateinit var database: SceytDatabase
+    private lateinit var dao: PendingMessageDeleteByTidDao
+    private lateinit var messageDao: MessageDao
+
+    @get:Rule
+    var instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @Before
+    fun setUp() {
+        database = Room.inMemoryDatabaseBuilder(
+            ApplicationProvider.getApplicationContext(),
+            SceytDatabase::class.java,
+        )
+            .fallbackToDestructiveMigration(false)
+            .allowMainThreadQueries()
+            .build()
+        dao = database.pendingMessageDeleteByTidDao()
+        messageDao = database.messageDao()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    private fun entity(
+        tid: Long,
+        channelId: Long = 1L,
+        deleteType: DeleteMessageType = DeleteMessageType.DeleteForEveryone,
+        createdAt: Long = tid,
+    ) = PendingMessageDeleteByTidEntity(
+        messageTid = tid,
+        channelId = channelId,
+        deleteType = deleteType,
+        createdAt = createdAt,
+    )
+
+    private fun message(tid: Long, channelId: Long = 1L) = MessageDb(
+        messageEntity = MessageEntity(
+            tid = tid,
+            id = tid,
+            channelId = channelId,
+            body = "body",
+            type = "text",
+            metadata = null,
+            createdAt = tid,
+            updatedAt = 0,
+            incoming = false,
+            isTransient = false,
+            silent = false,
+            deliveryStatus = MessageDeliveryStatus.Pending,
+            state = MessageState.Unmodified,
+            fromId = "user1",
+            markerCount = null,
+            mentionedUsersIds = null,
+            parentId = null,
+            replyCount = 0L,
+            displayCount = 0,
+            autoDeleteAt = null,
+            forwardingDetailsDb = null,
+            bodyAttribute = null,
+            unList = false,
+            disableMentionsCount = false,
+            viewOnce = false,
+        ),
+        from = null,
+        parent = null,
+        attachments = null,
+        userMarkers = null,
+        reactions = null,
+        reactionsTotals = null,
+        pendingReactions = null,
+        forwardingUser = null,
+        mentionedUsers = null,
+        poll = null,
+    )
+
+    @Test
+    fun insert_and_getAll_returnsStoredEntity() = runTest {
+        dao.insert(entity(tid = 1, deleteType = DeleteMessageType.DeleteHard))
+
+        val result = dao.getAll()
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first().messageTid).isEqualTo(1L)
+        assertThat(result.first().deleteType).isEqualTo(DeleteMessageType.DeleteHard)
+    }
+
+    @Test
+    fun insert_replacesOnConflictByTid() = runTest {
+        dao.insert(entity(tid = 1, deleteType = DeleteMessageType.DeleteForMe))
+        dao.insert(entity(tid = 1, deleteType = DeleteMessageType.DeleteForEveryone))
+
+        val result = dao.getAll()
+
+        assertThat(result).hasSize(1)
+        assertThat(result.first().deleteType).isEqualTo(DeleteMessageType.DeleteForEveryone)
+    }
+
+    @Test
+    fun getAll_orderedByCreatedAtAsc() = runTest {
+        dao.insert(entity(tid = 1, createdAt = 300))
+        dao.insert(entity(tid = 2, createdAt = 100))
+        dao.insert(entity(tid = 3, createdAt = 200))
+
+        assertThat(dao.getAll().map { it.messageTid }).isEqualTo(listOf(2L, 3L, 1L))
+    }
+
+    @Test
+    fun deleteByTid_removesOnlyThatRow() = runTest {
+        dao.insert(entity(tid = 1))
+        dao.insert(entity(tid = 2))
+
+        dao.deleteByTid(1L)
+
+        assertThat(dao.getAll().map { it.messageTid }).containsExactly(2L)
+    }
+
+    @Test
+    fun updateChannelId_remapsMatchingRows() = runTest {
+        dao.insert(entity(tid = 1, channelId = 10L))
+        dao.insert(entity(tid = 2, channelId = 10L))
+        dao.insert(entity(tid = 3, channelId = 20L))
+
+        val updated = dao.updateChannelId(oldChannelId = 10L, newChannelId = 99L)
+
+        assertThat(updated).isEqualTo(2)
+        assertThat(dao.getAll().filter { it.channelId == 99L }.map { it.messageTid })
+            .containsExactlyElementsIn(listOf(1L, 2L))
+        assertThat(dao.getAll().first { it.messageTid == 3L }.channelId).isEqualTo(20L)
+    }
+
+    // Core invariant: the pending-delete row must survive deletion of the message row
+    // (no foreign key / cascade), so the delete can be retried after the message is gone.
+    @Test
+    fun pendingRowSurvivesMessageDeletion() = runTest {
+        messageDao.upsertMessage(message(tid = 1))
+        dao.insert(entity(tid = 1))
+
+        messageDao.deleteMessageByTid(1L)
+
+        assertThat(messageDao.existsMessageByTid(1L)).isFalse()
+        assertThat(dao.getAll().map { it.messageTid }).containsExactly(1L)
+    }
+}

--- a/SceytChatUiKit/src/androidTest/java/com/sceyt/chatuikit/persistence/logicimpl/usecases/PendingChannelUseCasesTest.kt
+++ b/SceytChatUiKit/src/androidTest/java/com/sceyt/chatuikit/persistence/logicimpl/usecases/PendingChannelUseCasesTest.kt
@@ -93,6 +93,7 @@ class PendingChannelUseCasesTest {
             draftMessageDao = database.draftMessageDao(),
             pendingReactionDao = database.pendingReactionDao(),
             pendingMessageStateDao = database.pendingMessageStateDao(),
+            pendingMessageDeleteByTidDao = database.pendingMessageDeleteByTidDao(),
             channelsCache = channelsCache,
             messagesCache = messagesCache,
             channelSyncStateStore = syncStateStore

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/data/repositories/MessagesRepositoryImpl.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/data/repositories/MessagesRepositoryImpl.kt
@@ -415,6 +415,29 @@ class MessagesRepositoryImpl : MessagesRepository {
             })
     }
 
+    override suspend fun deleteMessageByTid(
+        channelId: Long,
+        tid: Long,
+        deleteType: DeleteMessageType,
+    ): SceytResponse<SceytMessage> = suspendCancellableCoroutine { continuation ->
+        // Build a message with id = 0 and only the tid set, so the SDK deletes it by tid.
+        val message = Message.MessageBuilder(channelId).setTid(tid).build()
+        ChannelOperator.build(channelId)
+            .deleteMessage(message, deleteType, object : MessageCallback {
+                override fun onResult(msg: Message) {
+                    continuation.safeResume(SceytResponse.Success(msg.toSceytUiMessage()))
+                }
+
+                override fun onError(ex: SceytException?) {
+                    SceytLog.e(
+                        TAG,
+                        "deleteMessageByTid error: ${ex?.message}, tid: $tid, channelId: $channelId, deleteType: $deleteType"
+                    )
+                    continuation.safeResume(SceytResponse.Error(ex))
+                }
+            })
+    }
+
     override suspend fun editMessage(
         channelId: Long,
         message: SceytMessage

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/DatabaseConstants.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/DatabaseConstants.kt
@@ -23,6 +23,7 @@ internal object DatabaseConstants {
     const val DRAFT_MESSAGE_USER_LINK_TABLE = "sceyt_draft_message_user_link_table"
     const val AUTO_DELETE_MESSAGES_TABLE = "sceyt_auto_delete_messages_table"
     const val PENDING_MESSAGE_STATE_TABLE = "sceyt_pending_message_state_table"
+    const val PENDING_MESSAGE_DELETE_BY_TID_TABLE = "sceyt_pending_message_delete_by_tid_table"
     const val LOAD_RANGE_TABLE = "sceyt_load_range_table"
 
     // Attachment

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/SceytDatabase.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/SceytDatabase.kt
@@ -20,6 +20,7 @@ import com.sceyt.chatuikit.persistence.database.dao.MarkerDao
 import com.sceyt.chatuikit.persistence.database.dao.MemberDao
 import com.sceyt.chatuikit.persistence.database.dao.MessageDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingMarkerDao
+import com.sceyt.chatuikit.persistence.database.dao.PendingMessageDeleteByTidDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingMessageStateDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingPollVoteDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingReactionDao
@@ -50,6 +51,7 @@ import com.sceyt.chatuikit.persistence.database.entity.messages.PollVoteEntity
 import com.sceyt.chatuikit.persistence.database.entity.messages.ReactionEntity
 import com.sceyt.chatuikit.persistence.database.entity.messages.ReactionTotalEntity
 import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMarkerEntity
+import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMessageDeleteByTidEntity
 import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMessageStateEntity
 import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingPollVoteEntity
 import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingReactionEntity
@@ -86,9 +88,10 @@ import com.sceyt.chatuikit.persistence.database.entity.user.UserMetadataEntity
         PollOptionEntity::class,
         PollVoteEntity::class,
         PendingPollVoteEntity::class,
+        PendingMessageDeleteByTidEntity::class,
         MessageFtsEntity::class,
     ],
-    version = 30,
+    version = 31,
     autoMigrations = [
         AutoMigration(from = 1, to = 2),
         AutoMigration(from = 2, to = 3),
@@ -116,6 +119,7 @@ import com.sceyt.chatuikit.persistence.database.entity.user.UserMetadataEntity
         AutoMigration(from = 26, to = 27),
         AutoMigration(from = 27, to = 28),
         AutoMigration(from = 29, to = 30),
+        AutoMigration(from = 30, to = 31),
     ]
 )
 
@@ -134,6 +138,7 @@ internal abstract class SceytDatabase : RoomDatabase() {
     abstract fun pendingMarkersDao(): PendingMarkerDao
     abstract fun pendingReactionDao(): PendingReactionDao
     abstract fun pendingMessageStateDao(): PendingMessageStateDao
+    abstract fun pendingMessageDeleteByTidDao(): PendingMessageDeleteByTidDao
     abstract fun fileChecksumDao(): FileChecksumDao
     abstract fun linkDao(): LinkDao
     abstract fun loadRangeDao(): LoadRangeDao

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/converters/MessageConverter.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/converters/MessageConverter.kt
@@ -2,6 +2,7 @@ package com.sceyt.chatuikit.persistence.database.converters
 
 import androidx.room.TypeConverter
 import com.sceyt.chat.models.message.BodyAttribute
+import com.sceyt.chat.models.message.DeleteMessageType
 import com.sceyt.chat.models.message.MarkerTotal
 import com.sceyt.chat.models.message.MessageState
 import com.sceyt.chatuikit.data.models.messages.MessageDeliveryStatus
@@ -39,6 +40,12 @@ class MessageConverter {
 
     @TypeConverter
     fun intToMessageState(value: Int) = value.toEnum<MessageState>()
+
+    @TypeConverter
+    fun deleteMessageTypeToInt(value: DeleteMessageType) = value.ordinal
+
+    @TypeConverter
+    fun intToDeleteMessageType(value: Int) = value.toEnum<DeleteMessageType>()
 
     @TypeConverter
     fun transferStateEnumToInt(value: TransferState?) = value?.ordinal

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/dao/PendingMessageDeleteByTidDao.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/dao/PendingMessageDeleteByTidDao.kt
@@ -1,0 +1,24 @@
+package com.sceyt.chatuikit.persistence.database.dao
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import com.sceyt.chatuikit.persistence.database.DatabaseConstants.PENDING_MESSAGE_DELETE_BY_TID_TABLE
+import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMessageDeleteByTidEntity
+
+@Dao
+internal interface PendingMessageDeleteByTidDao {
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    suspend fun insert(entity: PendingMessageDeleteByTidEntity)
+
+    @Query("SELECT * FROM $PENDING_MESSAGE_DELETE_BY_TID_TABLE ORDER BY createdAt ASC")
+    suspend fun getAll(): List<PendingMessageDeleteByTidEntity>
+
+    @Query("DELETE FROM $PENDING_MESSAGE_DELETE_BY_TID_TABLE WHERE messageTid = :tid")
+    suspend fun deleteByTid(tid: Long)
+
+    @Query("UPDATE $PENDING_MESSAGE_DELETE_BY_TID_TABLE SET channelId = :newChannelId WHERE channelId = :oldChannelId")
+    suspend fun updateChannelId(oldChannelId: Long, newChannelId: Long): Int
+}

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/entity/pendings/PendingMessageDeleteByTidEntity.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/database/entity/pendings/PendingMessageDeleteByTidEntity.kt
@@ -1,0 +1,15 @@
+package com.sceyt.chatuikit.persistence.database.entity.pendings
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import com.sceyt.chat.models.message.DeleteMessageType
+import com.sceyt.chatuikit.persistence.database.DatabaseConstants.PENDING_MESSAGE_DELETE_BY_TID_TABLE
+
+@Entity(tableName = PENDING_MESSAGE_DELETE_BY_TID_TABLE)
+internal data class PendingMessageDeleteByTidEntity(
+    @PrimaryKey
+    val messageTid: Long,
+    val channelId: Long,
+    val deleteType: DeleteMessageType,
+    val createdAt: Long,
+)

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/di/Modules.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/di/Modules.kt
@@ -139,6 +139,7 @@ internal fun databaseModule(enableDatabase: Boolean) = module {
     single { get<SceytDatabase>().pendingMarkersDao() }
     single { get<SceytDatabase>().pendingReactionDao() }
     single { get<SceytDatabase>().pendingMessageStateDao() }
+    single { get<SceytDatabase>().pendingMessageDeleteByTidDao() }
     single { get<SceytDatabase>().fileChecksumDao() }
     single { get<SceytDatabase>().linkDao() }
     single { get<SceytDatabase>().loadRangeDao() }

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logic/PersistenceMessagesLogic.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logic/PersistenceMessagesLogic.kt
@@ -102,6 +102,7 @@ interface PersistenceMessagesLogic {
     suspend fun sendAllPendingMessages()
     suspend fun sendAllPendingMarkers()
     suspend fun sendAllPendingMessageStateUpdates()
+    suspend fun sendAllPendingMessageDeletesByTid()
     suspend fun markMessagesAs(
         channelId: Long, marker: MarkerType,
         vararg ids: Long,

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logicimpl/PersistenceConnectionLogicImpl.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logicimpl/PersistenceConnectionLogicImpl.kt
@@ -80,6 +80,7 @@ internal class PersistenceConnectionLogicImpl(
                 messageLogic.sendAllPendingMarkers()
                 messageLogic.sendAllPendingMessages()
                 messageLogic.sendAllPendingMessageStateUpdates()
+                messageLogic.sendAllPendingMessageDeletesByTid()
                 reactionsLogic.sendAllPendingReactions()
                 pollLogic.sendAllPendingVotes()
                 _allPendingEventsSentFlow.tryEmit(Unit)

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logicimpl/message/PersistenceMessagesLogicImpl.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logicimpl/message/PersistenceMessagesLogicImpl.kt
@@ -53,6 +53,7 @@ import com.sceyt.chatuikit.persistence.database.dao.AttachmentDao
 import com.sceyt.chatuikit.persistence.database.dao.LoadRangeDao
 import com.sceyt.chatuikit.persistence.database.dao.MessageDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingMarkerDao
+import com.sceyt.chatuikit.persistence.database.dao.PendingMessageDeleteByTidDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingMessageStateDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingPollVoteDao
 import com.sceyt.chatuikit.persistence.database.dao.PollDao
@@ -63,6 +64,7 @@ import com.sceyt.chatuikit.persistence.database.entity.messages.MarkerEntity
 import com.sceyt.chatuikit.persistence.database.entity.messages.MessageDb
 import com.sceyt.chatuikit.persistence.database.entity.messages.PendingPollVoteDb
 import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMarkerEntity
+import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMessageDeleteByTidEntity
 import com.sceyt.chatuikit.persistence.database.entity.pendings.PendingMessageStateEntity
 import com.sceyt.chatuikit.persistence.database.entity.user.UserDb
 import com.sceyt.chatuikit.persistence.extensions.toArrayList
@@ -124,6 +126,7 @@ internal class PersistenceMessagesLogicImpl(
     private val reactionDao: ReactionDao,
     private val userDao: UserDao,
     private val pendingMessageStateDao: PendingMessageStateDao,
+    private val pendingMessageDeleteByTidDao: PendingMessageDeleteByTidDao,
     private val pollDao: PollDao,
     private val pendingPollVoteDao: PendingPollVoteDao,
     private val fileTransferService: FileTransferService,
@@ -962,6 +965,17 @@ internal class PersistenceMessagesLogicImpl(
                     state = it.transferState ?: TransferState.Uploading
                 )
             }
+            // The send request may already have reached the server, so persist a delete-by-tid
+            // intent (retried on reconnect) and attempt to delete it on the server now.
+            pendingMessageDeleteByTidDao.insert(
+                PendingMessageDeleteByTidEntity(
+                    messageTid = message.tid,
+                    channelId = channelId,
+                    deleteType = deleteType,
+                    createdAt = System.currentTimeMillis()
+                )
+            )
+            deleteMessageByTidImpl(channelId, message.tid, DeleteHard)
             return@withContext SceytResponse.Success(clonedMessage)
         }
 
@@ -1043,6 +1057,34 @@ internal class PersistenceMessagesLogicImpl(
             }
         }
         return response
+    }
+
+    private suspend fun deleteMessageByTidImpl(
+        channelId: Long,
+        tid: Long,
+        deleteType: DeleteMessageType
+    ): SceytResponse<SceytMessage> {
+        val response = messagesRepository.deleteMessageByTid(channelId, tid, deleteType)
+        response.onSuccessNotNull {
+            pendingMessageDeleteByTidDao.deleteByTid(tid)
+        }.onError {
+            val errorType = SDKErrorTypeEnum.fromValue(it?.type) ?: return@onError
+            if (!errorType.isResendable) {
+                pendingMessageDeleteByTidDao.deleteByTid(tid)
+                SceytLog.e(
+                    TAG,
+                    "Delete message by tid non-resendable error: ${it?.message}, errorType: ${errorType.value}" +
+                            "deleting pending delete by tid state from db for message tid:$tid"
+                )
+            }
+        }
+        return response
+    }
+
+    override suspend fun sendAllPendingMessageDeletesByTid() = withContext(dispatcherIO) {
+        pendingMessageDeleteByTidDao.getAll().forEach { entity ->
+            deleteMessageByTidImpl(entity.channelId, entity.messageTid, entity.deleteType)
+        }
     }
 
     override suspend fun getMessageFromServerById(

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logicimpl/usecases/MigratePendingChannelToRealChannelUseCase.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/logicimpl/usecases/MigratePendingChannelToRealChannelUseCase.kt
@@ -8,6 +8,7 @@ import com.sceyt.chatuikit.persistence.database.dao.ChannelDao
 import com.sceyt.chatuikit.persistence.database.dao.DraftMessageDao
 import com.sceyt.chatuikit.persistence.database.dao.LoadRangeDao
 import com.sceyt.chatuikit.persistence.database.dao.MessageDao
+import com.sceyt.chatuikit.persistence.database.dao.PendingMessageDeleteByTidDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingMessageStateDao
 import com.sceyt.chatuikit.persistence.database.dao.PendingReactionDao
 import com.sceyt.chatuikit.persistence.logicimpl.channel.ChannelsCache
@@ -23,6 +24,7 @@ internal class MigratePendingChannelToRealChannelUseCase(
     private val draftMessageDao: DraftMessageDao,
     private val pendingReactionDao: PendingReactionDao,
     private val pendingMessageStateDao: PendingMessageStateDao,
+    private val pendingMessageDeleteByTidDao: PendingMessageDeleteByTidDao,
     private val channelsCache: ChannelsCache,
     private val messagesCache: MessagesCache,
     private val channelSyncStateStore: ChannelSyncStateStore
@@ -44,6 +46,7 @@ internal class MigratePendingChannelToRealChannelUseCase(
         moveDraftToChannel(pendingChannelId, realChannelId)
         pendingReactionDao.updateChannelId(pendingChannelId, realChannelId)
         pendingMessageStateDao.updateChannelId(pendingChannelId, realChannelId)
+        pendingMessageDeleteByTidDao.updateChannelId(pendingChannelId, realChannelId)
 
         if (lastMessage != realChannel.lastMessage) {
             channelDao.updateLastMessage(

--- a/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/repositories/MessagesRepository.kt
+++ b/SceytChatUiKit/src/main/java/com/sceyt/chatuikit/persistence/repositories/MessagesRepository.kt
@@ -77,6 +77,12 @@ interface MessagesRepository {
         deleteType: DeleteMessageType,
     ): SceytResponse<SceytMessage>
 
+    suspend fun deleteMessageByTid(
+        channelId: Long,
+        tid: Long,
+        deleteType: DeleteMessageType,
+    ): SceytResponse<SceytMessage>
+
     suspend fun editMessage(
         channelId: Long,
         message: SceytMessage,


### PR DESCRIPTION
- Introduced `PendingMessageDeleteByTidEntity` and a corresponding DAO to persist message deletion requests initiated by local terminal ID (Tid).
- Added `deleteMessageByTid` to `MessagesRepository` and its implementation to allow the SDK to target messages for deletion before they have a server-assigned ID.
- Updated `PersistenceMessagesLogicImpl` to record a pending delete intent in the database before attempting the server-side deletion, ensuring the operation is retried if the initial request fails or the app is offline.
- Integrated `sendAllPendingMessageDeletesByTid` into the connection recovery flow in `PersistenceConnectionLogicImpl` to automatically synchronize pending deletions upon reconnection.
- Enhanced `MigratePendingChannelToRealChannelUseCase` to remap the `channelId` for pending deletion records when a temporary channel is migrated to a real channel.
- Updated `SceytDatabase` to version 31 with an auto-migration and added TypeConverters for `DeleteMessageType`.
- Added instrumentation tests in `PendingMessageDeleteByTidDaoTest` to verify persistence logic, including ordering and survival of pending records after message entity deletion.